### PR TITLE
optimize hydrator class generation

### DIFF
--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -84,7 +84,7 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
             array_values(array_filter(
                 $class->getProperties(),
                 static function (ReflectionProperty $property) use ($class) : bool {
-                    return ! ($property->isStatic() || $property->class !== $class->name);
+                    return ! ($property->isStatic() || $property->getDeclaringClass()->getName() !== $class->getName());
                 }
             ))
         ));

--- a/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
+++ b/src/GeneratedHydrator/CodeGenerator/Visitor/HydratorMethodsVisitor.php
@@ -83,8 +83,8 @@ class HydratorMethodsVisitor extends NodeVisitorAbstract
             $this->findAllInstanceProperties($class->getParentClass() ?: null), // of course PHP is shit.
             array_values(array_filter(
                 $class->getProperties(),
-                static function (ReflectionProperty $property) : bool {
-                    return ! $property->isStatic();
+                static function (ReflectionProperty $property) use ($class) : bool {
+                    return ! ($property->isStatic() || $property->class !== $class->name);
                 }
             ))
         ));

--- a/tests/GeneratedHydratorTest/CodeGenerator/Visitor/HydratorMethodsVisitorTest.php
+++ b/tests/GeneratedHydratorTest/CodeGenerator/Visitor/HydratorMethodsVisitorTest.php
@@ -7,8 +7,10 @@ namespace GeneratedHydratorTest\CodeGenerator\Visitor;
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 use GeneratedHydrator\CodeGenerator\Visitor\HydratorMethodsVisitor;
 use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -81,4 +83,106 @@ class HydratorMethodsVisitorTest extends TestCase
             [$staticClassName, $parser->parse('<?php ' . $staticClassCode)[0], ['taz']],
         ];
     }
+
+	/**
+	 * @dataProvider propertyAstProvider
+	 */
+	public function testPropertyCodeGeneration(string $className, Class_ $classNode, array $properties) : void
+	{
+		$visitor = new HydratorMethodsVisitor(new ReflectionClass($className));
+
+		/** @var Class_ $modifiedAst */
+		$modifiedNode = $visitor->leaveNode($classNode);
+
+		$constructors = $this->findConstructor($modifiedNode);
+		self::assertCount(1, $constructors);
+		$constructor = reset($constructors);
+
+		$hydratePropertyNames = $this->findAssignedPropertyNames(
+			$constructor,
+			'hydrateCallbacks',
+			'object',
+			function (Assign $assign) {
+				return $assign->var->name->name;
+			}
+		);
+		$extractPropertyNames = $this->findAssignedPropertyNames(
+			$constructor,
+			'extractCallbacks',
+			'values',
+			function (Assign $assign) {
+				return $assign->var->dim->value;
+			}
+		);
+
+		self::assertSameSize($properties, $hydratePropertyNames);
+		self::assertSameSize($properties, $extractPropertyNames);
+		self::assertCount(0, array_diff($properties, $hydratePropertyNames));
+		self::assertCount(0, array_diff($properties, $extractPropertyNames));
+	}
+
+	private function findConstructor(Class_ $class) : array {
+		return array_filter(
+			$class->stmts,
+			static function (Node $node): bool {
+				return $node instanceof ClassMethod && '__construct' === $node->name->name;
+			}
+		);
+	}
+
+	private function findAssignedPropertyNames(Node $node, string $callbackName, string $variableName, callable $mapper)
+	{
+		$finder = new NodeFinder();
+		$callbacks = $finder->find($node, function(Node $node) use ($callbackName) {
+			return $node instanceof Assign
+				&& $node->var->var->name instanceof Node\Identifier
+				&& $node->var->var->name->name === $callbackName;
+		});
+
+		$found = [];
+		foreach($callbacks as $callback) {
+			/** @noinspection SlowArrayOperationsInLoopInspection */
+			$found = array_merge($found, $finder->find($callback, function(Node $node) use ($variableName) {
+				return $node instanceof Assign
+					&& is_string($node->var->var->name)
+					&& $node->var->var->name === $variableName;
+			}));
+		}
+
+		return array_map($mapper, $found);
+	}
+
+	/**
+	 * @return Node[]
+	 */
+	public function propertyAstProvider(): array
+	{
+		$parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7);
+
+		$className = UniqueIdentifierGenerator::getIdentifier('Foo');
+		$classCode = 'class '.$className.' { private $bar; private $baz; protected $tab; '
+			.'protected $tar; }';
+
+		eval($classCode);
+
+		$subClassName = UniqueIdentifierGenerator::getIdentifier('Foo');
+		$subClassCode = 'class '.$subClassName.' extends '.$className.' { private $fuz; protected $buz; }';
+
+		eval($subClassCode);
+
+		$sub2ClassName = UniqueIdentifierGenerator::getIdentifier('Foo');
+		$sub2ClassCode = 'class '.$sub2ClassName.' extends '.$subClassName.' { protected $bis; }';
+
+		eval($sub2ClassCode);
+
+		return [
+			[$className, $parser->parse('<?php '.$classCode)[0], ['bar', 'baz', 'tab', 'tar']],
+			[$subClassName, $parser->parse('<?php '.$subClassCode)[0], ['bar', 'baz', 'tab', 'tar', 'fuz', 'buz']],
+			[
+				$sub2ClassName,
+				$parser->parse('<?php '.$sub2ClassCode)[0],
+				['bar', 'baz', 'tab', 'tar', 'fuz', 'buz', 'bis'],
+			],
+		];
+	}
 }


### PR DESCRIPTION
The reflection api returns public and protected properties of all super classes. With this commit we stop reading and writing those properties multiple times in the generated hydrator classes. This improves performance in situations when hydration of deep hierarchies is required. 